### PR TITLE
updated to handle reverse proxy with __init__ parameter

### DIFF
--- a/docs/source/tour.rst
+++ b/docs/source/tour.rst
@@ -176,6 +176,17 @@ Responder gives you the ability to mount another ASGI / WSGI app at a subroute::
 
 That's it!
 
+Reverse Proxy Responder (e.g. nginx, traefik)
+-----------------------------
+
+Reverse proxy Responder at a subroute:
+
+    import responder
+
+    api = responder.API(reverse_proxy_route="/demo") # must not end with trailing "/"
+
+Responder's interactive docs, schema.yml, and static routes will all work as normal!
+
 Single-Page Web Apps
 --------------------
 

--- a/responder/api.py
+++ b/responder/api.py
@@ -66,7 +66,7 @@ class API:
         contact=None,
         license=None,
         openapi=None,
-        reverse_proxy_path:str=None,
+        reverse_proxy_path: str = None,
         openapi_route="/schema.yml",
         static_dir="static",
         static_route="/static",
@@ -93,19 +93,24 @@ class API:
         ## set up handler for reverse proxied api
         if reverse_proxy_path is not None:
             # check for exact route str format to ensure proper prefix
-            if isinstance(reverse_proxy_path, str) and reverse_proxy_path[-1] != "/" and reverse_proxy_path[0] == "/":
+            if (
+                isinstance(reverse_proxy_path, str)
+                and reverse_proxy_path[-1] != "/"
+                and reverse_proxy_path[0] == "/"
+            ):
                 pass
             else:
                 # invlaid route prefix format
-                raise ValueError("""reverse_proxy_path str must start with "/" and cannot end with "/", got: {reverse_proxy_path}""".format(
-                    reverse_proxy_path=reverse_proxy_path)
+                raise ValueError(
+                    """reverse_proxy_path str must start with "/" and cannot end with "/", got: {reverse_proxy_path}""".format(
+                        reverse_proxy_path=reverse_proxy_path
                     )
+                )
 
         # assign either to None (api is mounted at root), or assign to error checked reverse proxy path
         # self.add_route handles route prefixing
         self.reverse_proxy_path = reverse_proxy_path
 
-        
         # set up static dir/route
         if static_dir is not None:
             if static_route is None:
@@ -113,9 +118,11 @@ class API:
             static_dir = Path(os.path.abspath(static_dir))
 
         self.static_dir = static_dir
-        
+
         # handles reverse proxy, if configured to
-        self.static_route = self.make_route(static_route) if static_route is not None else static_route 
+        self.static_route = (
+            self.make_route(static_route) if static_route is not None else static_route
+        )
 
         self.built_in_templates_dir = Path(
             os.path.abspath(os.path.dirname(__file__) + "/templates")
@@ -172,8 +179,10 @@ class API:
                     / "static"
                 ).resolve()
             )
-            self.static_route = self.static_route # already handled reverse proxy, if applicable
-            self.mount(self.static_route, self.whitenoise) 
+            self.static_route = (
+                self.static_route
+            )  # already handled reverse proxy, if applicable
+            self.mount(self.static_route, self.whitenoise)
 
         self.formats = get_formats()
 
@@ -465,29 +474,33 @@ class API:
 
         self.lifespan_handler.add_event_handler(event_type, handler)
 
-    def make_route(
-        self,
-        route:str):
+    def make_route(self, route: str):
         """returns route, prefixed by reverse_proxy_path if the API is configured to do so during the __init__
         
         param route: A string representation of the route.        
         """
 
         # Note: I considered putting this in self.add_route, but static_route also needs the reverse proxy path during the __init__
-        
+
         if not isinstance(route, str):
-            raise ValueError("""route isn't a string, got: {route} of type {_type}""".format(route=str(route), _type=type(route)))
+            raise ValueError(
+                """route isn't a string, got: {route} of type {_type}""".format(
+                    route=str(route), _type=type(route)
+                )
+            )
 
         if route[0] != "/":
-            raise ValueError("""route doesn't start with "/", got: {route}""".format(route=route))
-        
+            raise ValueError(
+                """route doesn't start with "/", got: {route}""".format(route=route)
+            )
+
         if self.reverse_proxy_path is not None:
             # return reverse proxied route; error checking on self.reverse_proxy_path is done during the __init__
             return self.reverse_proxy_path + route
         else:
             # returns route as is
             return route
-    
+
     def add_route(
         self,
         route=None,
@@ -695,7 +708,9 @@ class API:
             langs=["javascript", "python"],
             code_style=None,
             static_url=self.static_url,
-            schema_url=self.make_route("/schema.yml"), # will have to handle reverse proxy here as well
+            schema_url=self.make_route(
+                "/schema.yml"
+            ),  # will have to handle reverse proxy here as well
         )
 
     def template(self, name_, **values):

--- a/responder/api.py
+++ b/responder/api.py
@@ -66,7 +66,7 @@ class API:
         contact=None,
         license=None,
         openapi=None,
-        reverse_proxy_path: str = None,
+        reverse_proxy_route: str = None,
         openapi_route="/schema.yml",
         static_dir="static",
         static_route="/static",
@@ -91,25 +91,25 @@ class API:
         self.openapi_version = openapi
 
         ## set up handler for reverse proxied api
-        if reverse_proxy_path is not None:
+        if reverse_proxy_route is not None:
             # check for exact route str format to ensure proper prefix
             if (
-                isinstance(reverse_proxy_path, str)
-                and reverse_proxy_path[-1] != "/"
-                and reverse_proxy_path[0] == "/"
+                isinstance(reverse_proxy_route, str)
+                and reverse_proxy_route[-1] != "/"
+                and reverse_proxy_route[0] == "/"
             ):
                 pass
             else:
                 # invlaid route prefix format
                 raise ValueError(
-                    """reverse_proxy_path str must start with "/" and cannot end with "/", got: {reverse_proxy_path}""".format(
-                        reverse_proxy_path=reverse_proxy_path
+                    """reverse_proxy_route str must start with "/" and cannot end with "/", got: {reverse_proxy_route}""".format(
+                        reverse_proxy_route=reverse_proxy_route
                     )
                 )
 
         # assign either to None (api is mounted at root), or assign to error checked reverse proxy path
         # self.add_route handles route prefixing
-        self.reverse_proxy_path = reverse_proxy_path
+        self.reverse_proxy_route = reverse_proxy_route
 
         # set up static dir/route
         if static_dir is not None:
@@ -475,7 +475,7 @@ class API:
         self.lifespan_handler.add_event_handler(event_type, handler)
 
     def make_route(self, route: str):
-        """returns route, prefixed by reverse_proxy_path if the API is configured to do so during the __init__
+        """returns route, prefixed by reverse_proxy_route if the API is configured to do so during the __init__
         
         param route: A string representation of the route.        
         """
@@ -494,9 +494,9 @@ class API:
                 """route doesn't start with "/", got: {route}""".format(route=route)
             )
 
-        if self.reverse_proxy_path is not None:
-            # return reverse proxied route; error checking on self.reverse_proxy_path is done during the __init__
-            return self.reverse_proxy_path + route
+        if self.reverse_proxy_route is not None:
+            # return reverse proxied route; error checking on self.reverse_proxy_route is done during the __init__
+            return self.reverse_proxy_route + route
         else:
             # returns route as is
             return route
@@ -512,7 +512,7 @@ class API:
         websocket=False,
         before_request=False,
     ):
-        """Adds a route to the API.  Prefixes route with reverse_proxy_path if configured to during cls.__init__
+        """Adds a route to the API.  Prefixes route with reverse_proxy_route if configured to during cls.__init__
 
         :param route: A string representation of the route.
         :param endpoint: The endpoint for the route -- can be a callable, or a class.
@@ -542,7 +542,7 @@ class API:
         if default:
             self.default_endpoint = endpoint
 
-        if self.reverse_proxy_path is not None:
+        if self.reverse_proxy_route is not None:
             route = self.make_route(route)
 
         self.routes[route] = Route(route, endpoint, websocket=websocket)

--- a/responder/api.py
+++ b/responder/api.py
@@ -113,7 +113,9 @@ class API:
             static_dir = Path(os.path.abspath(static_dir))
 
         self.static_dir = static_dir
-        self.static_route = self.make_route(static_route) # handles reverse proxy, if configured to
+        
+        # handles reverse proxy, if configured to
+        self.static_route = self.make_route(static_route) if static_route is not None else static_route 
 
         self.built_in_templates_dir = Path(
             os.path.abspath(os.path.dirname(__file__) + "/templates")

--- a/responder/api.py
+++ b/responder/api.py
@@ -93,7 +93,7 @@ class API:
         ## set up handler for reverse proxied api
         if reverse_proxy_path is not None:
             # check for exact route str format to ensure proper prefix
-            if isinstance(reverse_proxy_path, str) and reverse_proxy_path[:-1] != "/" and reverse_proxy_path[0] == "/":
+            if isinstance(reverse_proxy_path, str) and reverse_proxy_path[-1] != "/" and reverse_proxy_path[0] == "/":
                 pass
             else:
                 # invlaid route prefix format
@@ -172,7 +172,7 @@ class API:
                     / "static"
                 ).resolve()
             )
-            self.static_route = self.make_route(self.static_route) # handles reverse proxy, if applicable
+            self.static_route = self.static_route # already handled reverse proxy, if applicable
             self.mount(self.static_route, self.whitenoise) 
 
         self.formats = get_formats()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -20,11 +20,11 @@ def current_dir():
 def api():
     return responder.API(debug=False, allowed_hosts=[";"])
 
+
 @pytest.fixture
 def reverse_proxied_api():
-    return responder.API(debug=False, allowed_hosts=[";"],
-    reverse_proxy_path="/demo"
-    )
+    return responder.API(debug=False, allowed_hosts=[";"], reverse_proxy_path="/demo")
+
 
 @pytest.fixture
 def session(api):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -20,6 +20,11 @@ def current_dir():
 def api():
     return responder.API(debug=False, allowed_hosts=[";"])
 
+@pytest.fixture
+def reverse_proxied_api():
+    return responder.API(debug=False, allowed_hosts=[";"],
+    reverse_proxy_path="/demo"
+    )
 
 @pytest.fixture
 def session(api):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -23,7 +23,7 @@ def api():
 
 @pytest.fixture
 def reverse_proxied_api():
-    return responder.API(debug=False, allowed_hosts=[";"], reverse_proxy_path="/demo")
+    return responder.API(debug=False, allowed_hosts=[";"], reverse_proxy_route="/demo")
 
 
 @pytest.fixture

--- a/tests/test_responder.py
+++ b/tests/test_responder.py
@@ -102,22 +102,32 @@ def test_status_code(api):
 
     assert api.requests.get("http://;/").status_code == responder.status_codes.HTTP_416
 
+
 def test_reverse_proxied_api(reverse_proxied_api):
     TEXT = "home"
-    
+
     @reverse_proxied_api.route("/")
     def hello(req, resp):
         resp.text = TEXT
 
-    url = "http://;{reverse_proxy_path}/".format(reverse_proxy_path=reverse_proxied_api.reverse_proxy_path)
-    assert reverse_proxied_api.requests.get(url).status_code == responder.status_codes.HTTP_200
+    url = "http://;{reverse_proxy_path}/".format(
+        reverse_proxy_path=reverse_proxied_api.reverse_proxy_path
+    )
+    assert (
+        reverse_proxied_api.requests.get(url).status_code
+        == responder.status_codes.HTTP_200
+    )
     assert reverse_proxied_api.requests.get(url).text == TEXT
+
 
 def test_incorrectly_reverse_proxied_api():
     with pytest.raises(ValueError):
-        responder.API(debug=False, allowed_hosts=[";"],
-            reverse_proxy_path="/demo/" # can't have trailing slash
-            )
+        responder.API(
+            debug=False,
+            allowed_hosts=[";"],
+            reverse_proxy_path="/demo/",  # can't have trailing slash
+        )
+
 
 def test_json_media(api):
     dump = {"life": 42}
@@ -430,7 +440,6 @@ def test_documentation():
     r = api.requests.get("/docs")
     assert "html" in r.text
 
-
     def test_reverse_proxied_documentation():
         import responder
         from marshmallow import Schema, fields
@@ -459,7 +468,7 @@ def test_documentation():
             contact=contact,
             license=license,
             allowed_hosts=["testserver", ";"],
-            reverse_proxy_path=REVERSE_PROXY_PATH
+            reverse_proxy_path=REVERSE_PROXY_PATH,
         )
 
         @api.schema("Pet")
@@ -487,6 +496,7 @@ def test_documentation():
         # check schema
         r = api.requests.get(f"{REVERSE_PROXY_PATH}/schema.yml")
         assert r.ok
+
 
 def test_mount_wsgi_app(api, flask):
     @api.route("/")
@@ -837,10 +847,11 @@ def test_staticfiles_custom_route(tmpdir):
     r = session.get(f"{static_route}")
     assert r.status_code == api.status_codes.HTTP_404
 
+
 def test_staticfiles_custom_route_reverse_proxy(tmpdir):
     static_dir = tmpdir.mkdir("static")
     static_route = "/custom/static/route"
-    
+
     # difference from last test case
     REVERSE_PROXY_PATH = "/demo"
 
@@ -848,12 +859,14 @@ def test_staticfiles_custom_route_reverse_proxy(tmpdir):
 
     # difference from last test case
     reverse_proxied_api = responder.API(
-        static_dir=str(static_dir), static_route=static_route,
-        reverse_proxy_path=REVERSE_PROXY_PATH) 
+        static_dir=str(static_dir),
+        static_route=static_route,
+        reverse_proxy_path=REVERSE_PROXY_PATH,
+    )
     session = reverse_proxied_api.session()
 
     static_route = reverse_proxied_api.static_route
-    
+
     # ok
     r = session.get(f"{static_route}/{asset.basename}")
     assert r.status_code == reverse_proxied_api.status_codes.HTTP_200
@@ -907,6 +920,7 @@ def test_staticfiles_none_dir_route(tmpdir):
     # dir listing
     r = session.get(f"{static_route}")
     assert r.status_code == api.status_codes.HTTP_404
+
 
 def test_response_html_property(api):
     @api.route("/")

--- a/tests/test_responder.py
+++ b/tests/test_responder.py
@@ -110,8 +110,8 @@ def test_reverse_proxied_api(reverse_proxied_api):
     def hello(req, resp):
         resp.text = TEXT
 
-    url = "http://;{reverse_proxy_path}/".format(
-        reverse_proxy_path=reverse_proxied_api.reverse_proxy_path
+    url = "http://;{reverse_proxy_route}/".format(
+        reverse_proxy_route=reverse_proxied_api.reverse_proxy_route
     )
     assert (
         reverse_proxied_api.requests.get(url).status_code
@@ -125,7 +125,7 @@ def test_incorrectly_reverse_proxied_api():
         responder.API(
             debug=False,
             allowed_hosts=[";"],
-            reverse_proxy_path="/demo/",  # can't have trailing slash
+            reverse_proxy_route="/demo/",  # can't have trailing slash
         )
 
 
@@ -456,7 +456,7 @@ def test_documentation():
             "url": "https://www.apache.org/licenses/LICENSE-2.0.html",
         }
 
-        REVERSE_PROXY_PATH = "/demo"
+        reverse_proxy_route = "/demo"
 
         api = responder.API(
             title="Web Service",
@@ -468,7 +468,7 @@ def test_documentation():
             contact=contact,
             license=license,
             allowed_hosts=["testserver", ";"],
-            reverse_proxy_path=REVERSE_PROXY_PATH,
+            reverse_proxy_route=reverse_proxy_route,
         )
 
         @api.schema("Pet")
@@ -490,11 +490,11 @@ def test_documentation():
             resp.media = PetSchema().dump({"name": "little orange"})
 
         # check docs
-        r = api.requests.get(f"{REVERSE_PROXY_PATH}/docs")
+        r = api.requests.get(f"{reverse_proxy_route}/docs")
         assert "html" in r.text
 
         # check schema
-        r = api.requests.get(f"{REVERSE_PROXY_PATH}/schema.yml")
+        r = api.requests.get(f"{reverse_proxy_route}/schema.yml")
         assert r.ok
 
 
@@ -853,7 +853,7 @@ def test_staticfiles_custom_route_reverse_proxy(tmpdir):
     static_route = "/custom/static/route"
 
     # difference from last test case
-    REVERSE_PROXY_PATH = "/demo"
+    reverse_proxy_route = "/demo"
 
     asset = create_asset(static_dir)
 
@@ -861,7 +861,7 @@ def test_staticfiles_custom_route_reverse_proxy(tmpdir):
     reverse_proxied_api = responder.API(
         static_dir=str(static_dir),
         static_route=static_route,
-        reverse_proxy_path=REVERSE_PROXY_PATH,
+        reverse_proxy_route=reverse_proxy_route,
     )
     session = reverse_proxied_api.session()
 


### PR DESCRIPTION
Addresses https://github.com/taoufik07/responder/issues/274

The PR adds an `__init__` parameter `reverse_proxy_path` to prefix all routes

Notes:
- added make_route function since `static_route` requires the prefix and is configured during the `__init__` and not with `api.add_route`
  - `api.make_route` checks that route's begin with "/"
  - if `reverse_proxy_path` is not set, `api.make_route` returns the `route` unchanged

 test cases :

- `docs_route`, `openapi_route`, `static_route` all function  when` reverse_proxy_path` is set
- test incorrect `reverse_proxy_path` (can't have trailing "/")