### PR TITLE
add a few tests for API and remove some dead code

### DIFF
--- a/responder/api.py
+++ b/responder/api.py
@@ -153,25 +153,12 @@ class API:
             self._static_app = StaticFiles(directory=self.static_dir)
         return self._static_app
 
-    @staticmethod
-    def _notfound_wsgi_app(environ, start_response):
-        start_response("404 NOT FOUND", [("Content-Type", "text/plain")])
-        return [b"Not Found."]
-
     def before_request(self, websocket=False):
         def decorator(f):
             self.router.before_request(f, websocket=websocket)
             return f
 
         return decorator
-
-    @property
-    def before_http_requests(self):
-        return self.before_requests.get("http", [])
-
-    @property
-    def before_ws_requests(self):
-        return self.before_requests.get("ws", [])
 
     def add_middleware(self, middleware_cls, **middleware_config):
         self.app = middleware_cls(self.app, **middleware_config)


### PR DESCRIPTION
Increasing the coverage of api.py to 86%

- use pytest.parametrize to test cors and hsts parameters usage
- use pytest.parametrize to factorize test_staticfiles_custom_route
- add tests for path_matches_route and Route() with no endpoint
- test Jinja template rendering from a file

- remove   _notfound_wsgi_app, before_ws_requests, before_http_requests

they didn't seem used anywhere and the before_* method were broken, referring to
self.before_requests that doesn't exist anymore