### PR TITLE
upgrade pluggy to 0.13.0 to support importlib.metadata on python 3.8

### DIFF
--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -548,10 +548,10 @@
         },
         "pluggy": {
             "hashes": [
-                "sha256:0825a152ac059776623854c1543d65a4ad408eb3d33ee114dff91e57ec6ae6fc",
-                "sha256:b9817417e95936bf75d85d3f8767f7df6cdde751fc40aed3bb3074cbcb77757c"
+                "sha256:0db4b7601aae1d35b4a033282da476845aa19185c1e6964b25cf324b5e4ec3e6",
+                "sha256:fa5fa1622fa6dd5c030e9cad086fa19ef6a0cf6d7a2d12318e10cb49d6d68f34"
             ],
-            "version": "==0.12.0"
+            "version": "==0.13.0"
         },
         "py": {
             "hashes": [


### PR DESCRIPTION
tests were failing on Python 3.8:
```
  File "/home/travis/virtualenv/python3.8-dev/lib/python3.8/site-packages/pluggy/manager.py", line 6, in <module>

    import importlib_metadata

ModuleNotFoundError: No module named 'importlib_metadata'
```

importlib-metadata is now in the standard lib (as `importlib.metadata`)
pluggy needs to be bumped to reflect this change
