### PR TITLE
Async templates require enable_async in jinja2 Environment

### DIFF
--- a/docs/source/quickstart.rst
+++ b/docs/source/quickstart.rst
@@ -85,9 +85,10 @@ Usage::
   def hello(req, resp, name):
       resp.html = templates.render("hello.html", name=name)
 
-      
+
 Also a ``render_async`` is available::
 
+    templates = Templates(enable_async=True)
     resp.html = await templates.render_async("hello.html", who=who)
 
 You can also use the existing ``api.template(filename, *args, **kwargs)`` to render templates::

--- a/responder/templates.py
+++ b/responder/templates.py
@@ -4,10 +4,14 @@ import jinja2
 
 
 class Templates:
-    def __init__(self, directory="templates", autoescape=True, context=None):
+    def __init__(
+        self, directory="templates", autoescape=True, context=None, enable_async=False
+    ):
         self.directory = directory
         self._env = jinja2.Environment(
-            loader=jinja2.FileSystemLoader([str(self.directory)]), autoescape=autoescape
+            loader=jinja2.FileSystemLoader([str(self.directory)]),
+            autoescape=autoescape,
+            enable_async=enable_async,
         )
         self.default_context = {} if context is None else {**context}
         self._env.globals.update(self.default_context)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -56,3 +56,12 @@ def schema():
             return f"Hello {name}"
 
     return graphene.Schema(query=Query)
+
+
+@pytest.fixture
+def template_path(tmpdir):
+    # create a Jinja template file on the filesystem
+    template_name = "test.html"
+    template_file = tmpdir.mkdir("static").join(template_name)
+    template_file.write("{{ var }}")
+    return template_file


### PR DESCRIPTION
When trying to test the render_async() feature I realized that it wasn't working

Jinja2 `Environment` instance has to be created with `enable_async=True`

This PR depends on #395, it should be merged after.