### PR TITLE
fix issues related to using `static=true` in `api.add_route()` and `static_route` in `responder.API()`

### DIFF
--- a/responder/api.py
+++ b/responder/api.py
@@ -218,7 +218,7 @@ class API:
         index = (self.static_dir / "index.html").resolve()
         if os.path.exists(index):
             with open(index, "r") as f:
-                resp.html = "Hello world !"
+                resp.html = f.read()
         else:
             resp.status_code = status_codes.HTTP_404
             resp.text = "Not found."


### PR DESCRIPTION
In responder 2.0.3, Using `static=true` in `api.add_route()` and `static_route` in `responder.API()` had some issues:
* `static=true` would always return "Hello world !"
* After fixing the above, when using `static=true`, if `index.html` required other resources (such as `index.js`), responder would return a 404 (because the GET request would use the route `/index.js`). Alternatively, specifying `static_route` to be `/` would result in a 404 for trying to get `index.html` because responder would check the static files mounted app first

This PR provides these issue in the following ways:
* `_staic_response()` returns the contents of `index.html` (as is intended)
* Router's `__call__` checks routed added by `add_route` (or `@api.route`) first. This allows for the default static route to return `index.html` via `_static_response()`, and for additional resources required by `index.html` to be returned via the static files mounted app
