### PR TITLE
Added add_schema to responder.API

### DIFF
--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -615,7 +615,7 @@
         "pygments": {
             "hashes": [
                 "sha256:647344a061c249a3b74e230c739f434d7ea4d8b1d5f3721bc0f3558049b38f44",
-                "sha256:aa931c0bd5daa25c475afadb2147115134cfe501f0656828cbe7cb566c7123bc"
+                "sha256:ff7a40b4860b727ab48fad6360eb351cc1b33cbf9b15a0f689ca5353e9463324"
             ],
             "version": "==2.6.1"
         },

--- a/responder/api.py
+++ b/responder/api.py
@@ -151,6 +151,17 @@ class API:
     def add_middleware(self, middleware_cls, **middleware_config):
         self.app = middleware_cls(self.app, **middleware_config)
 
+    def add_schema(self, name, f, **options):
+        """Adds a schema
+        Usage::
+            from marshmallow import Schema, fields
+            class PetSchema(Schema):
+                name = fields.Str()
+
+            api.add_schema("Pet", PetSchema)
+        """
+        self.openapi.add_schema(name=name, schema=f, **options)
+
     def schema(self, name, **options):
         """Decorator for creating new routes around function and class definitions.
         Usage::

--- a/tests/test_responder.py
+++ b/tests/test_responder.py
@@ -414,6 +414,38 @@ def test_schema_generation():
     assert dump["openapi"] == "3.0.2"
 
 
+def test_add_schema_generation():
+    import responder
+    from marshmallow import Schema, fields
+
+    api = responder.API(title="Web Service", openapi="3.0.2")
+
+    class PetSchema(Schema):
+        name = fields.Str()
+
+    @api.route("/")
+    def route(req, resp):
+        """A cute furry animal endpoint.
+        ---
+        get:
+            description: Get a random pet
+            responses:
+                200:
+                    description: A pet to be returned
+                    schema:
+                        $ref: "#/components/schemas/Pet"
+        """
+        resp.media = PetSchema().dump({"name": "little orange"})
+
+    api.add_schema("Pet", PetSchema)
+
+    r = api.requests.get("http://;/schema.yml")
+    dump = yaml.safe_load(r.content)
+
+    assert dump
+    assert dump["openapi"] == "3.0.2"
+
+
 def test_documentation_explicit():
     import responder
     from responder.ext.schema import Schema as OpenAPISchema


### PR DESCRIPTION
## Overview
Added `add_schema` to `responder.API`.

A schema can be added with `API.schema`, but cannot be added with add_schema like `ext.schema`. Therefore, it is convenient to have `API.add_schema`.

## Example

```python
import responder
from marshmallow import Schema, fields

api = responder.API()

class PetSchema(Schema):
    name = fields.Str()

api.add_schema("Pet", PetSchema)
```

