### PR TITLE
Fix hash in pygment from piwheel to pypi.

### DIFF
--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -615,7 +615,7 @@
         "pygments": {
             "hashes": [
                 "sha256:647344a061c249a3b74e230c739f434d7ea4d8b1d5f3721bc0f3558049b38f44",
-                "sha256:aa931c0bd5daa25c475afadb2147115134cfe501f0656828cbe7cb566c7123bc"
+                "sha256:ff7a40b4860b727ab48fad6360eb351cc1b33cbf9b15a0f689ca5353e9463324"
             ],
             "version": "==2.6.1"
         },


### PR DESCRIPTION
Changed hash value from piwheels to pypi.

With this pr, #429 and #428 and #425 will also pass with CI.