### PR TITLE
bump uvicorn 0.11.* to 0.11.7

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ if sys.argv[-1] == "publish":
 
 required = [
     "starlette==0.13.*",
-    "uvicorn>=0.11.*,<0.13",
+    "uvicorn>=0.11.7,<0.13",
     "aiofiles",
     "pyyaml",
     "requests",

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ if sys.argv[-1] == "publish":
 
 required = [
     "starlette==0.13.*",
-    "uvicorn==0.11.*",
+    "uvicorn>=0.11.*,<0.13",
     "aiofiles",
     "pyyaml",
     "requests",


### PR DESCRIPTION
Upgrade uvicorn to version 0.11.7 or later.
fix security problem.
CVE-2020-7695
CVE-2020-7694
