### PR TITLE
Allow function endpoints to specify HTTP methods via @api.route()

### DIFF
--- a/responder/api.py
+++ b/responder/api.py
@@ -186,6 +186,7 @@ class API:
         check_existing=True,
         websocket=False,
         before_request=False,
+        methods=None,
     ):
         """Adds a route to the API.
 
@@ -193,6 +194,7 @@ class API:
         :param endpoint: The endpoint for the route -- can be a callable, or a class.
         :param default: If ``True``, all unknown requests will route to this view.
         :param static: If ``True``, and no endpoint was passed, render "static/index.html", and it will become a default route.
+        :param methods: A list of HTTP methods to accept. Only applies if websocket is false. If None, accept all HTTP methods.
         """
 
         # Path
@@ -209,6 +211,7 @@ class API:
             websocket=websocket,
             before_request=before_request,
             check_existing=check_existing,
+            methods=methods,
         )
 
     async def _static_response(self, req, resp):
@@ -264,7 +267,7 @@ class API:
 
         self.router.add_event_handler(event_type, handler)
 
-    def route(self, route=None, **options):
+    def route(self, route=None, methods=None, **options):
         """Decorator for creating new routes around function and class definitions.
 
         Usage::
@@ -276,7 +279,7 @@ class API:
         """
 
         def decorator(f):
-            self.add_route(route, f, **options)
+            self.add_route(route, f, methods=methods, **options)
             return f
 
         return decorator

--- a/tests/test_responder.py
+++ b/tests/test_responder.py
@@ -1018,3 +1018,14 @@ def test_route_without_endpoint(api):
     api.add_route("/")
     route = api.router.routes[0]
     assert route.endpoint_name == "_static_response"
+
+
+def test_route_with_http_methods(api, url):
+    @api.route("/", methods=["GET"])
+    def onlyGet(req, resp):
+        resp.text = "hello world!"
+
+    route = api.router.routes[0]
+    assert route.methods == ["GET"]
+    assert api.requests.get(url("/")).text == "hello world!"
+    assert api.requests.post(url("/")).status_code == api.status_codes.HTTP_404

--- a/tests/test_responder.py
+++ b/tests/test_responder.py
@@ -1028,4 +1028,4 @@ def test_route_with_http_methods(api, url):
     route = api.router.routes[0]
     assert route.methods == ["GET"]
     assert api.requests.get(url("/")).text == "hello world!"
-    assert api.requests.post(url("/")).status_code == api.status_codes.HTTP_404
+    assert api.requests.post(url("/")).status_code == api.status_codes.HTTP_405


### PR DESCRIPTION
Fixes #403 