### PR TITLE
docs: fix simple typo, mashmallow -> marshmallow

### DIFF
--- a/responder/ext/schema/__init__.py
+++ b/responder/ext/schema/__init__.py
@@ -97,7 +97,7 @@ class Schema:
         return self._apispec.to_yaml()
 
     def add_schema(self, name, schema, check_existing=True):
-        """Adds a mashmallow schema to the API specification."""
+        """Adds a marshmallow schema to the API specification."""
         if check_existing:
             assert name not in self.schemas
 


### PR DESCRIPTION
There is a small typo in responder/ext/schema/__init__.py.

Should read `marshmallow` rather than `mashmallow`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md