### PR TITLE
Add uvicorn[extra]

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ if sys.argv[-1] == "publish":
 
 required = [
     "starlette==0.13.*",
-    "uvicorn>=0.11.7,<0.13",
+    "uvicorn[standard]>=0.12.0,<0.13.3",
     "aiofiles",
     "pyyaml",
     "requests",


### PR DESCRIPTION
c.f. https://github.com/encode/uvicorn/blob/master/CHANGELOG.md#changed-1

We should remove the `uvircorn` dependency in the future.

closes #449 