### PR TITLE
cleanup req, res initializations in Router.default_response

### DIFF
--- a/responder/routes.py
+++ b/responder/routes.py
@@ -293,9 +293,6 @@ class Router:
             await websocket_close(receive, send)
             return
 
-        request = Request(scope, receive)
-        response = Response(request, formats=get_formats())
-
         raise HTTPException(status_code=status_codes.HTTP_404)
 
     def _resolve_route(self, scope):


### PR DESCRIPTION
In `Router.default_response()`, for a "http" type scope, 404 exc is raised directly as resp (handled by exc middleware).
No need to initialize Request, Response.