### PR TITLE
Bugfix: wrong use of header "Encoding"

### DIFF
--- a/responder/models.py
+++ b/responder/models.py
@@ -210,18 +210,8 @@ class Request:
         return (await self.content).decode(await self.encoding)
 
     @property
-    async def declared_encoding(self):
-        if "Encoding" in self.headers:
-            return self.headers["Encoding"]
-
-    @property
     async def apparent_encoding(self):
         """The apparent encoding, provided by the chardet library. Must be awaited."""
-        declared_encoding = await self.declared_encoding
-
-        if declared_encoding:
-            return declared_encoding
-
         return chardet.detect(await self.content)["encoding"] or DEFAULT_ENCODING
 
     @property

--- a/responder/models.py
+++ b/responder/models.py
@@ -308,9 +308,9 @@ class Response:
             content = self.content
             if self.mimetype is not None:
                 headers["Content-Type"] = self.mimetype
-            if self.mimetype == "text/plain" and self.encoding is not None:
-                headers["Encoding"] = self.encoding
-                content = content.encode(self.encoding)
+            if self.mimetype == "text/plain":
+                # Follow StarletteResponse.charset, which is set as "utf-8"
+                content = content.encode(getattr(StarletteResponse, "charset", "utf-8"))
             return (content, headers)
 
         for format in self.formats:


### PR DESCRIPTION
Wrong use of experimental header "Encoding". Seems a bug.

```python
class Request:
    # added by Reitz, 10/14/18
    # 36c57393180a03e19ca65424cf6d1bcb808b904e
    @property
    async def declared_encoding(self):
        if "Encoding" in self.headers:
            return self.headers["Encoding"]

class Response:
    @property
    async def body(self):
        if self._stream is not None:
            return (self._stream(), {})

        if self.content is not None:
            headers = {}
            content = self.content
            if self.mimetype is not None:
                headers["Content-Type"] = self.mimetype
            if self.mimetype == "text/plain" and self.encoding is not None:
                # added by taoufik07, 2/20/19
                # 0b261252e1b8865ecc4667dd35674199fce796eb
                headers["Encoding"] = self.encoding
                content = content.encode(self.encoding)
            return (content, headers)
```

Experimental header "Encoding" has a very different format compared what we thought, after I checked the RFCs,

- https://tools.ietf.org/html/rfc1505
- https://tools.ietf.org/html/rfc1154

Here's some examples of this experimental headers.

```
Encoding: 107 Text
Encoding: 458 uuencode LZW tar (Unix binary object)
Encoding: 496 Text, 8 Text Signature
```

---

Another possible reason of the intro of "Encoding" by Reitz, may be that he'd like users set encoding in the "endpoint function" or the "before_request" function like this, `Request.headers["Encoding"]="utf-8"`. But the chance is slim for this assumption cause we could set encoding on `Request.encoding` directly.